### PR TITLE
added import gzip to mop.py

### DIFF
--- a/mop.py
+++ b/mop.py
@@ -4,6 +4,7 @@ import os
 import re
 import io
 import subprocess
+import gzip
 
 #from parse_read import parse_read
 


### PR DESCRIPTION
For me mop.py doesn't work on gzipped files without "import gzip"